### PR TITLE
Load bundled project and simplify editor

### DIFF
--- a/app/src/main/java/com/rg/mapper/android/ui/Dialogs.kt
+++ b/app/src/main/java/com/rg/mapper/android/ui/Dialogs.kt
@@ -18,10 +18,13 @@ fun HallDialog(
     onApply: (Hall) -> Unit
 ) {
     if (!visible) return
+    val pxPerMeter = (ppcm.takeIf { it > 0f } ?: 1f) * 100f
     var number by remember { mutableStateOf(initial.number.toString()) }
     var name by remember { mutableStateOf(initial.name) }
-    var w by remember { mutableStateOf(String.format("%.1f", initial.wPx / (ppcm * 100f))) }
-    var h by remember { mutableStateOf(String.format("%.1f", initial.hPx / (ppcm * 100f))) }
+    var x by remember { mutableStateOf(String.format("%.2f", initial.xPx / pxPerMeter)) }
+    var y by remember { mutableStateOf(String.format("%.2f", initial.yPx / pxPerMeter)) }
+    var w by remember { mutableStateOf(String.format("%.2f", initial.wPx / pxPerMeter)) }
+    var h by remember { mutableStateOf(String.format("%.2f", initial.hPx / pxPerMeter)) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -30,6 +33,8 @@ fun HallDialog(
             Column {
                 OutlinedTextField(value = number, onValueChange = { number = it }, label = { Text("Номер зала") })
                 OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Название") })
+                OutlinedTextField(value = x, onValueChange = { x = it }, label = { Text("Смещение X (м)") })
+                OutlinedTextField(value = y, onValueChange = { y = it }, label = { Text("Смещение Y (м)") })
                 OutlinedTextField(value = w, onValueChange = { w = it }, label = { Text("Ширина (м)") })
                 OutlinedTextField(value = h, onValueChange = { h = it }, label = { Text("Высота (м)") })
             }
@@ -37,11 +42,15 @@ fun HallDialog(
         confirmButton = {
             Button(onClick = {
                 val n = number.toIntOrNull() ?: initial.number
-                val wm = w.toFloatOrNull()?.coerceAtLeast(0.1f) ?: (initial.wPx / (ppcm * 100f))
-                val hm = h.toFloatOrNull()?.coerceAtLeast(0.1f) ?: (initial.hPx / (ppcm * 100f))
-                val wp = wm * ppcm * 100f
-                val hp = hm * ppcm * 100f
-                onApply(initial.copy(number = n, name = name, wPx = wp, hPx = hp))
+                val xm = x.toFloatOrNull()?.coerceAtLeast(0f) ?: (initial.xPx / pxPerMeter)
+                val ym = y.toFloatOrNull()?.coerceAtLeast(0f) ?: (initial.yPx / pxPerMeter)
+                val wm = w.toFloatOrNull()?.coerceAtLeast(0.1f) ?: (initial.wPx / pxPerMeter)
+                val hm = h.toFloatOrNull()?.coerceAtLeast(0.1f) ?: (initial.hPx / pxPerMeter)
+                val xp = xm * pxPerMeter
+                val yp = ym * pxPerMeter
+                val wp = wm * pxPerMeter
+                val hp = hm * pxPerMeter
+                onApply(initial.copy(number = n, name = name, xPx = xp, yPx = yp, wPx = wp, hPx = hp))
             }) { Text("Сохранить") }
         },
         dismissButton = { OutlinedButton(onClick = onDismiss) { Text("Отмена") } }
@@ -58,8 +67,11 @@ fun AnchorDialog(
     onApply: (Anchor) -> Unit
 ) {
     if (!visible) return
+    val pxPerMeter = (ppcm.takeIf { it > 0f } ?: 1f) * 100f
     var number by remember { mutableStateOf(initial.number.toString()) }
     var z by remember { mutableStateOf(String.format("%.1f", initial.zCm / 100f)) }
+    var x by remember { mutableStateOf(String.format("%.2f", initial.xScenePx / pxPerMeter)) }
+    var y by remember { mutableStateOf(String.format("%.2f", initial.yScenePx / pxPerMeter)) }
     var extras by remember { mutableStateOf(initial.extraHalls.joinToString(",")) }
     var bound by remember { mutableStateOf(initial.bound) }
 
@@ -69,6 +81,8 @@ fun AnchorDialog(
         text = {
             Column {
                 OutlinedTextField(value = number, onValueChange = { number = it }, label = { Text("Номер якоря") })
+                OutlinedTextField(value = x, onValueChange = { x = it }, label = { Text("Координата X (м)") })
+                OutlinedTextField(value = y, onValueChange = { y = it }, label = { Text("Координата Y (м)") })
                 OutlinedTextField(value = z, onValueChange = { z = it }, label = { Text("Координата Z (м)") })
                 OutlinedTextField(value = extras, onValueChange = { extras = it }, label = { Text("Доп. залы (через запятую)") })
                 Row { Checkbox(checked = bound, onCheckedChange = { bound = it }); Text("Переходный") }
@@ -79,8 +93,19 @@ fun AnchorDialog(
                 val n = number.toIntOrNull() ?: initial.number
                 val zCm = ((z.toFloatOrNull() ?: (initial.zCm / 100f)) * 100f).roundToInt()
                 val ex = extras.split(',').mapNotNull { it.trim().toIntOrNull() }
-                onApply(initial.copy(number = n, zCm = zCm, extraHalls = ex, bound = bound,
-                    mainHall = initial.mainHall ?: hallForDefault))
+                val xm = x.toFloatOrNull() ?: (initial.xScenePx / pxPerMeter)
+                val ym = y.toFloatOrNull() ?: (initial.yScenePx / pxPerMeter)
+                onApply(
+                    initial.copy(
+                        number = n,
+                        xScenePx = xm * pxPerMeter,
+                        yScenePx = ym * pxPerMeter,
+                        zCm = zCm,
+                        extraHalls = ex,
+                        bound = bound,
+                        mainHall = initial.mainHall ?: hallForDefault
+                    )
+                )
             }) { Text("Сохранить") }
         },
         dismissButton = { OutlinedButton(onClick = onDismiss) { Text("Отмена") } }
@@ -96,9 +121,14 @@ fun ZoneDialog(
     onApply: (Zone) -> Unit
 ) {
     if (!visible) return
+    val pxPerMeter = (ppcm.takeIf { it > 0f } ?: 1f) * 100f
     var number by remember { mutableStateOf(initial.zoneNum.toString()) }
     var type by remember { mutableStateOf(initial.type) }
     var angle by remember { mutableStateOf(initial.angleDeg.toString()) }
+    var x by remember { mutableStateOf(String.format("%.2f", initial.blX_Px / pxPerMeter)) }
+    var y by remember { mutableStateOf(String.format("%.2f", initial.blY_Px / pxPerMeter)) }
+    var w by remember { mutableStateOf(String.format("%.2f", initial.wPx / pxPerMeter)) }
+    var h by remember { mutableStateOf(String.format("%.2f", initial.hPx / pxPerMeter)) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -114,13 +144,31 @@ fun ZoneDialog(
                     FilterChip(selected = type == ZoneType.BOUND, onClick = { type = ZoneType.BOUND }, label = { Text("Переходная") })
                 }
                 OutlinedTextField(value = angle, onValueChange = { angle = it }, label = { Text("Угол (°)") })
+                OutlinedTextField(value = x, onValueChange = { x = it }, label = { Text("Смещение X (м)") })
+                OutlinedTextField(value = y, onValueChange = { y = it }, label = { Text("Смещение Y от верха (м)") })
+                OutlinedTextField(value = w, onValueChange = { w = it }, label = { Text("Ширина (м)") })
+                OutlinedTextField(value = h, onValueChange = { h = it }, label = { Text("Высота (м)") })
             }
         },
         confirmButton = {
             Button(onClick = {
                 val n = number.toIntOrNull() ?: initial.zoneNum
                 val ang = angle.toIntOrNull()?.coerceIn(-90, 90) ?: initial.angleDeg
-                onApply(initial.copy(zoneNum = n, type = type, angleDeg = ang))
+                val xm = x.toFloatOrNull()?.coerceAtLeast(0f) ?: (initial.blX_Px / pxPerMeter)
+                val ym = y.toFloatOrNull()?.coerceAtLeast(0f) ?: (initial.blY_Px / pxPerMeter)
+                val wm = w.toFloatOrNull()?.coerceAtLeast(0.1f) ?: (initial.wPx / pxPerMeter)
+                val hm = h.toFloatOrNull()?.coerceAtLeast(0.1f) ?: (initial.hPx / pxPerMeter)
+                onApply(
+                    initial.copy(
+                        zoneNum = n,
+                        type = type,
+                        angleDeg = ang,
+                        blX_Px = xm * pxPerMeter,
+                        blY_Px = ym * pxPerMeter,
+                        wPx = wm * pxPerMeter,
+                        hPx = hm * pxPerMeter
+                    )
+                )
             }) { Text("Сохранить") }
         },
         dismissButton = { OutlinedButton(onClick = onDismiss) { Text("Отмена") } }

--- a/app/src/main/java/com/rg/mapper/android/ui/PlanCanvas.kt
+++ b/app/src/main/java/com/rg/mapper/android/ui/PlanCanvas.kt
@@ -26,9 +26,7 @@ import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import com.rg.mapper.android.model.*
-import kotlin.math.abs
 import kotlin.math.max
-import kotlin.math.min
 import kotlin.math.round
 
 @Composable
@@ -91,63 +89,9 @@ fun PlanCanvas(
                     },
                     onTap = { pos ->
                         val scene = toScene(pos)
-                        when (state.mode) {
-                            ToolMode.Calibrate -> {
-                                if (state.tempPointA == null) state.tempPointA = scene
-                                else { state.tempPointA = scene; onLongPressEdit(Selection()) }
-                            }
-                            ToolMode.AddHall -> {
-                                if (!state.gridCalibrated) return@detectTapGestures
-                                if (state.tempPointA == null) state.tempPointA = scene
-                                else {
-                                    val h = state.addHallByPoints(state.tempPointA!!, scene)
-                                    state.selection = Selection(hallNumber = h.number)
-                                    onLongPressEdit(state.selection)
-                                    state.tempPointA = null
-                                }
-                            }
-                            ToolMode.AddZone -> {
-                                val hall = state.hallAt(scene) ?: return@detectTapGestures
-                                if (state.tempPointA == null) {
-                                    state.tempPointA = scene
-                                } else {
-                                    val a = state.tempPointA!!
-                                    if (state.hallAt(scene)?.number == hall.number) {
-                                        val blX = min(a.x, scene.x) - hall.xPx
-                                        val blY = max(a.y, scene.y) - hall.yPx // bottom_left_y от ВЕРХА
-                                        val w = abs(scene.x - a.x)
-                                        val h = abs(scene.y - a.y)
-                                        val z = Zone(
-                                            hallNumber = hall.number,
-                                            zoneNum = state.nextZoneNumber(hall.number),
-                                            type = ZoneType.ENTER,
-                                            angleDeg = 0,
-                                            blX_Px = blX,
-                                            blY_Px = blY,
-                                            wPx = w,
-                                            hPx = h
-                                        )
-                                        state.zones.add(z)
-                                        state.selection = Selection(hallNumber = hall.number, zoneKey = hall.number to z.zoneNum)
-                                        onLongPressEdit(state.selection)
-                                    }
-                                    state.tempPointA = null
-                                }
-                            }
-                            ToolMode.AddAnchor -> {
-                                val hall = state.hallAt(scene) ?: return@detectTapGestures
-                                val a = Anchor(
-                                    number = state.nextAnchorNumber(),
-                                    xScenePx = scene.x,
-                                    yScenePx = scene.y,
-                                    zCm = 0,
-                                    mainHall = hall.number
-                                )
-                                state.anchors.add(a)
-                                state.selection = Selection(anchorNumber = a.number)
-                                onLongPressEdit(state.selection)
-                            }
-                            else -> Unit
+                        if (state.mode == ToolMode.Calibrate) {
+                            if (state.tempPointA == null) state.tempPointA = scene
+                            else { state.tempPointA = scene; onLongPressEdit(Selection()) }
                         }
                     }
                 )
@@ -358,9 +302,6 @@ fun PlanCanvas(
         // подсказка
         val hint = when (state.mode) {
             ToolMode.Calibrate -> "Калибровка: два тапа — 2 точки"
-            ToolMode.AddHall   -> "Добавление зала: два тапа — противоположные углы"
-            ToolMode.AddZone   -> "Добавление зоны: два тапа внутри зала"
-            ToolMode.AddAnchor -> "Добавление якоря: тап по залу"
             else               -> "Панорама: свайп одним пальцем; Зум: щипок; Долгий тап — редактировать"
         }
         drawIntoCanvas {

--- a/app/src/main/java/com/rg/mapper/android/ui/PlanEditorState.kt
+++ b/app/src/main/java/com/rg/mapper/android/ui/PlanEditorState.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.*
 import com.rg.mapper.android.model.*
 import kotlin.math.*
 
-enum class ToolMode { Cursor, Calibrate, AddHall, AddZone, AddAnchor }
+enum class ToolMode { Cursor, Calibrate }
 
 data class Selection(
     val hallNumber: Int? = null,
@@ -38,36 +38,6 @@ class PlanEditorState {
     fun clearAll() {
         halls.clear(); zones.clear(); anchors.clear()
         selection = Selection(); tempPointA = null
-    }
-
-    fun addHallByPoints(a: androidx.compose.ui.geometry.Offset, b: androidx.compose.ui.geometry.Offset): Hall {
-        val x0 = min(a.x, b.x); val y0 = min(a.y, b.y)
-        val x1 = max(a.x, b.x); val y1 = max(a.y, b.y)
-        val stepPx = pixelPerCm * gridStepCm
-        fun snap(v: Float) = if (stepPx > 0f) round(v / stepPx) * stepPx else v
-        val sx0 = snap(x0); val sy0 = snap(y0)
-        var sx1 = snap(x1); var sy1 = snap(y1)
-        if (sx1 == sx0) sx1 = sx0 + stepPx
-        if (sy1 == sy0) sy1 = sy0 + stepPx
-        val hall = Hall(
-            number = nextHallNumber(),
-            name = "",
-            xPx = sx0, yPx = sy0,
-            wPx = (sx1 - sx0), hPx = (sy1 - sy0)
-        )
-        halls.add(hall); return hall
-    }
-
-    fun nextHallNumber(): Int = (halls.maxOfOrNull { it.number } ?: 0) + 1
-    fun nextZoneNumber(hallNumber: Int): Int = (zones.filter { it.hallNumber == hallNumber }.maxOfOrNull { it.zoneNum } ?: 0) + 1
-    fun nextAnchorNumber(): Int = (anchors.maxOfOrNull { it.number } ?: 0) + 1
-
-    fun resnapAllToGrid() {
-        val stepPx = pixelPerCm * gridStepCm
-        fun snap(v: Float) = if (stepPx > 0f) round(v / stepPx) * stepPx else v
-        halls.replaceAll { it.copy(xPx = snap(it.xPx), yPx = snap(it.yPx)) }
-        anchors.replaceAll { it.copy(xScenePx = snap(it.xScenePx), yScenePx = snap(it.yScenePx)) }
-        zones.replaceAll { it.copy(blX_Px = snap(it.blX_Px), blY_Px = snap(it.blY_Px)) }
     }
 
     fun hallAt(scene: androidx.compose.ui.geometry.Offset): Hall? =

--- a/app/src/main/res/raw/default_project.json
+++ b/app/src/main/res/raw/default_project.json
@@ -1,0 +1,102 @@
+{
+  "image_data": "",
+  "pixel_per_cm_x": 2.5,
+  "pixel_per_cm_y": 2.5,
+  "grid_step_cm": 50.0,
+  "lock_halls": false,
+  "lock_zones": false,
+  "lock_anchors": false,
+  "halls": [
+    {
+      "num": 1,
+      "name": "Основной зал",
+      "x_px": 100.0,
+      "y_px": 80.0,
+      "w_px": 2000.0,
+      "h_px": 1200.0,
+      "zones": [
+        {
+          "zone_num": 1,
+          "zone_type": "Входная зона",
+          "zone_angle": 0,
+          "bottom_left_x": 200.0,
+          "bottom_left_y": 400.0,
+          "w_px": 420.0,
+          "h_px": 320.0
+        },
+        {
+          "zone_num": 1,
+          "zone_type": "Выходная зона",
+          "zone_angle": 0,
+          "bottom_left_x": 1180.0,
+          "bottom_left_y": 620.0,
+          "w_px": 380.0,
+          "h_px": 300.0
+        },
+        {
+          "zone_num": 2,
+          "zone_type": "Переходная",
+          "zone_angle": 15,
+          "bottom_left_x": 860.0,
+          "bottom_left_y": 940.0,
+          "w_px": 520.0,
+          "h_px": 260.0
+        }
+      ]
+    },
+    {
+      "num": 2,
+      "name": "Склад",
+      "x_px": 2300.0,
+      "y_px": 80.0,
+      "w_px": 1200.0,
+      "h_px": 900.0,
+      "zones": [
+        {
+          "zone_num": 1,
+          "zone_type": "Входная зона",
+          "zone_angle": 0,
+          "bottom_left_x": 180.0,
+          "bottom_left_y": 360.0,
+          "w_px": 320.0,
+          "h_px": 240.0
+        }
+      ]
+    }
+  ],
+  "anchors": [
+    {
+      "number": 1,
+      "x": 420.0,
+      "y": 320.0,
+      "z": 250,
+      "main_hall": 1,
+      "extra_halls": [2]
+    },
+    {
+      "number": 2,
+      "x": 1520.0,
+      "y": 540.0,
+      "z": 250,
+      "main_hall": 1,
+      "extra_halls": []
+    },
+    {
+      "number": 3,
+      "x": 2640.0,
+      "y": 420.0,
+      "z": 240,
+      "main_hall": 2,
+      "extra_halls": []
+    },
+    {
+      "number": 4,
+      "x": 2980.0,
+      "y": 720.0,
+      "z": 240,
+      "main_hall": 2,
+      "extra_halls": [1],
+      "bound": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- load a bundled default project at startup instead of offering project creation actions
- restrict editor tools to cursor and calibration modes while cleaning up canvas interactions
- allow editing coordinates and dimensions for halls, zones, and anchors through updated dialogs

## Testing
- ./gradlew --console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68e66868bcc083319949043f2d95a760